### PR TITLE
abstract: improve reading

### DIFF
--- a/bip-0181.md
+++ b/bip-0181.md
@@ -15,8 +15,9 @@
 
 ## Abstract
 
-This BIP describes the Utreexo accumulator and its operations. It lays down how to update the
-accumulator as well as how to generate and verify inclusion proofs for elements in the accumulator.
+This BIP describes the Utreexo accumulator. It specifies the operations of the accumulator, 
+including how it is updated as elements are added and removed, and how to generate and verify 
+inclusion proofs demonstrating that a given element is part of the set.
 
 ## Motivation
 


### PR DESCRIPTION
The term `accumulator` is used three times without defining it, requiring the reader to already know what it is. Added an inline definition.