### PR TITLE
motivation: improve reading

### DIFF
--- a/bip-0181.md
+++ b/bip-0181.md
@@ -20,25 +20,18 @@ accumulator as well as how to generate and verify inclusion proofs for elements 
 
 ## Motivation
 
-The Bitcoin network is composed of a set of nodes that validate blocks and
-transactions as they are received. These nodes need to keep track of the current state of the network in order to
-fulfill their role. Most importantly, they must maintain a record of all coins that
-have been created but not yet spent, a collection known as the UTXO set.
+The Bitcoin network is composed of different types of nodes. Among them, full nodes validate blocks and transactions as they are received. To fulfill their role, these nodes must maintain a record of all coins that have been created but not yet spent, a collection known as the UTXO set.
 
-This set is typically stored in a database that must be accessed frequently and cannot
-be pruned. As a result, the cost of running a node is directly tied to the size
-of the UTXO set. Since it can grow indefinitely, bounded only by block size, it represents a
+This set is typically stored in a database that must be accessed frequently and unlike block data, cannot
+be discarded. As a result, the cost of running a full node is directly tied to the size
+of the UTXO set. Since it can grow indefinitely, bounded only by the rate of block production, it represents a
 long-term scalability concern.
 
-Utreexo is a dynamic accumulator that enables the UTXO set to be represented in just a few kilobytes,
-by requiring peers to provide additional proof data to verify the inclusion of a UTXO in the
-accumulator. This allows for the construction of extremely lightweight nodes capable of performing
-the same validation as a full node, without the need to store the entire UTXO set.
+Utreexo is a dynamic cryptographic accumulator that enables the UTXO set to be represented in just a few kilobytes, by requiring peers that support Utreexo to provide inclusion proofs for the UTXOs being spent. This allows for the construction of nodes that perform the same full validation as a standard full node, without the need to store the entire UTXO set.
 
 This BIP defines how the Utreexo accumulator works, defining the data structure and algorithms used to
 maintain the accumulator, as well as how to generate and verify inclusion proofs for elements in the accumulator.
-It does not define how the accumulator is used in the Bitcoin protocol, but rather provides a foundation for future
-BIPs that will define how to integrate Utreexo into Bitcoin validation and P2P network protocol.
+It does not define how the accumulator is used in the Bitcoin protocol, but rather provides a foundation for BIP-182 and BIP-183, which define how to integrate Utreexo into Bitcoin transaction validation and P2P network protocol respectively.
 
 ## License
 


### PR DESCRIPTION
Changes proposed:

- The text described full nodes as if they were the only type of node in the Bitcoin network. Changes were made to explicit that the network is composed of different node types and scoped the UTXO set requirement correctly to full nodes only.

- Also stating that the UTXO set "cannot be pruned" is misleading since Bitcoin Core supports pruned mode for Block data only.

- The text stated that the UTXO set is "bounded only by block size". The block size limit bounds the rate of growth per block, not the total size of the set which is unbounded over time. Changed to "bounded only by the rate of block production".

- Added "cryptographic" to "dynamic accumulator" for precision.

- Replaced "future BIPs" with explicit references to BIP-182 and BIP-183, which already exist.