### PR TITLE
preliminaries: improve reading and clarity

### DIFF
--- a/bip-0181.md
+++ b/bip-0181.md
@@ -46,15 +46,17 @@ This document is licensed under the BSD-3-Clause license.
 
 ## Preliminaries
 
-An accumulator is a cryptographic data structure that allows for the compact representation of a set,
-enabling efficient membership proofs without requiring storage of the entire set. In the context of Utreexo,
-the accumulator tracks the current set of unspent transaction outputs (UTXOs).
+An accumulator is a value constructed by recursively applying a combining function to a set of elements.
+In the context of Utreexo, that combining function is a cryptographic hash function applied to pairs of values,
+forming a cryptographic accumulator. This allows the UTXO set to be represented compactly, enabling efficient
+membership proofs without requiring storage of the entire set.
 
-The Utreexo accumulator is based on an append-only Merkle tree design introduced in [^1],
-which provides logarithmic-sized inclusion proofs. Utreexo extends this design to support dynamic updates,
-specifically enabling deletions from the set—a requirement for tracking UTXO spends in Bitcoin.
-To accommodate this, Utreexo changes the storage requirement from the accumulator design in [^1] to $O(log_2(N))$,
-where N is the number of elements ever added to the set, while still keeping proof sizes small and verification efficient.
+The Utreexo accumulator builds on the append-only Merkle forest design of Reyzin and Yakoubov [^1],
+where the accumulator value is a vector of tree roots and inclusion proofs consist of the sibling hashes
+along the path from a leaf to its root. Utreexo extends this design to support deletions, while preserving
+the $O(log_2(N))$ size of the accumulator state, where N is the total number of elements ever added,
+and introducing a deletion mechanism suited to Bitcoin's requirements. Unlike additions, which leave existing
+proofs valid without update, deletions require holders of inclusion proofs to update them as the Merkle forest is restructured.
 
 ## Merkle Forest
 


### PR DESCRIPTION
Changes:

- `accumulator` was described as a cryptographic data structure, which is imprecise. An `accumulator` is a value produced by repeatedly applying a combining function to a set of elements.

- There was a claim stating that Utreexo changes the storage requirement from Yakoubov's article to `O(log N)`. In fact the article already has `O(log N)` accumulator state as explicitly stated in its Figure 3. The new text correctly states that
Utreexo preserves the `O(log N)` accumulator state while adding deletion support.

- Added more detail about additions and deletions: additions leave existing proofs valid without any update, while deletions require proof holders to update their proofs as the Merkle forest is restructured.